### PR TITLE
display backtesting charts when bot is started with backtesting argument

### DIFF
--- a/Backtesting/collectors/exchanges/exchange_history_collector.py
+++ b/Backtesting/collectors/exchanges/exchange_history_collector.py
@@ -88,6 +88,7 @@ class ExchangeHistoryDataCollector(AbstractExchangeHistoryCollector):
 
     async def get_ohlcv_history(self, exchange, symbol, time_frame):
         candles: list = await self.exchange.get_symbol_prices(symbol, time_frame)
+        self.exchange_manager.uniformize_candles_if_necessary(candles)
         await self.save_ohlcv(exchange=exchange, symbol=symbol, time_frame=time_frame, candle=candles,
                               timestamp=[candle[0] for candle in candles], multiple=True)
 

--- a/Interfaces/web/models/backtesting.py
+++ b/Interfaces/web/models/backtesting.py
@@ -53,9 +53,9 @@ def get_data_files_with_description():
 def start_backtesting_using_specific_files(files, source, reset_tentacle_config=False):
     try:
         tools = WebInterface.tools
-        if tools[BOT_TOOLS_STRATEGY_OPTIMIZER] and tools[BOT_TOOLS_STRATEGY_OPTIMIZER].get_is_computing():
+        if tools[BOT_TOOLS_STRATEGY_OPTIMIZER] and tools[BOT_TOOLS_STRATEGY_OPTIMIZER].is_in_progress():
             return False, "Optimizer already running"
-        elif tools[BOT_TOOLS_BACKTESTING] and tools[BOT_TOOLS_BACKTESTING].get_is_computing():
+        elif tools[BOT_TOOLS_BACKTESTING] and tools[BOT_TOOLS_BACKTESTING].is_in_progress():
             return False, "A backtesting is already running"
         else:
             if reset_tentacle_config:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9078616/73121106-c3aff180-3f76-11ea-8907-e0d4a1758572.png)
(after https://github.com/Drakkar-Software/OctoBot-Backtesting/pull/16 and https://github.com/Drakkar-Software/OctoBot-Trading/pull/87)