### PR TITLE
make arbitrage trading mode not backtestable

### DIFF
--- a/Services/Interfaces/web_interface/templates/backtesting.html
+++ b/Services/Interfaces/web_interface/templates/backtesting.html
@@ -63,7 +63,7 @@
             </div>
         {% else %}
             <div class="alert alert-warning mt-1 text-center" role="alert">
-                <a class="alert-link" href="{{ url_for('config_tentacle', name=activated_trading_mode.get_name()) }}">{{ activated_trading_mode.get_name() }}</a> is not compatible with the current backtesting engine.
+                <a class="alert-link" href="{{ url_for('config_tentacle', name=activated_trading_mode.get_name()) }}">{{ activated_trading_mode.get_name() }}</a> can't be used in backtesting for now.
             </div>
         {% endif %}
     </div>

--- a/Services/Interfaces/web_interface/templates/config_tentacle.html
+++ b/Services/Interfaces/web_interface/templates/config_tentacle.html
@@ -153,7 +153,7 @@
                     </div>
                 {% else %}
                     <div class="col-8 alert alert-warning mt-1 text-center" role="alert">
-                        <a class="alert-link" href="{{ url_for('config_tentacle', name=activated_trading_mode.get_name()) }}">{{ activated_trading_mode.get_name() }}</a> is not compatible with the current backtesting engine.
+                        <a class="alert-link" href="{{ url_for('config_tentacle', name=activated_trading_mode.get_name()) }}">{{ activated_trading_mode.get_name() }}</a> can't be used in backtesting for now.
                     </div>
                 {% endif %}
                 <div class="col-2 offset-md-2">

--- a/Trading/Mode/arbitrage_trading_mode/arbitrage_trading_mode.py
+++ b/Trading/Mode/arbitrage_trading_mode/arbitrage_trading_mode.py
@@ -98,6 +98,10 @@ class ArbitrageTradingMode(AbstractTradingMode):
         """
         return False
 
+    @staticmethod
+    def is_backtestable():
+        return False
+
 
 class ArbitrageModeConsumer(AbstractTradingModeConsumer):
     ARBITRAGE_CONTAINER_KEY = "arbitrage"


### PR DESCRIPTION
need to adapt backtesting to octobot channels, require multiple exchange and update trading mode config to trade with selected exchanges.
Summarized in https://github.com/Drakkar-Software/OctoBot-Tentacles/issues/259