### PR TITLE
[WebInterface] display all config options but default

### DIFF
--- a/Services/Interfaces/web_interface/static/js/common/json_editor_settings.js
+++ b/Services/Interfaces/web_interface/static/js/common/json_editor_settings.js
@@ -74,3 +74,4 @@ class ConfirmArray extends JSONEditor.defaults.editors.array {
 JSONEditor.defaults.themes.octobot = OctoBotTheme;
 JSONEditor.defaults.editors.array = ConfirmArray;
 JSONEditor.defaults.options.theme = 'octobot';
+JSONEditor.defaults.options.required_by_default = true;


### PR DESCRIPTION
in tentacles config, when the current config is missing config keys, display them anyway