### PR TITLE
[Trading][DailyTradingMode] Fix decimal errors

### DIFF
--- a/Evaluator/Strategies/mixed_strategies_evaluator/tests/test_simple_strategy_evaluator.py
+++ b/Evaluator/Strategies/mixed_strategies_evaluator/tests/test_simple_strategy_evaluator.py
@@ -47,24 +47,24 @@ class SimpleStrategyEvaluatorTest(abstract_strategy_test.AbstractStrategyTest):
         # market: -44.248234106962656
         # market: -34.87003936300901
         # market: -45.18518518518518
-        await self.run_test_slow_downtrend(-9.26, -29.321, -16.191, -15.932)
+        await self.run_test_slow_downtrend(-9.26, -29.321, -16.191, -15.864)
 
     async def test_sharp_downtrend(self):
         # market: -30.271723049610415
         # market: -32.091097308488614
-        await self.run_test_sharp_downtrend(-7.577, -22.088)
+        await self.run_test_sharp_downtrend(-7.578, -22.09)
 
     async def test_flat_markets(self):
         # market: 5.052093571849795
         # market: 3.4840425531915002
         # market: -12.732688011913623
         # market: -34.64150943396227
-        await self.run_test_flat_markets(2.429, 8.981, -5.819, -18.679)
+        await self.run_test_flat_markets(2.429, 8.981, -5.819, -18.693)
 
     async def test_slow_uptrend(self):
         # market: 32.524679029957184
         # market: 6.25
-        await self.run_test_slow_uptrend(4.95, 5.35)
+        await self.run_test_slow_uptrend(4.95, 5.348)
 
     async def test_sharp_uptrend(self):
         # market: 24.56254050550875
@@ -73,7 +73,7 @@ class SimpleStrategyEvaluatorTest(abstract_strategy_test.AbstractStrategyTest):
 
     async def test_up_then_down(self):
         # market: 1.1543668450702853
-        await self.run_test_up_then_down(8.714)
+        await self.run_test_up_then_down(8.713)
 
 
 async def test_default_run(strategy_tester):

--- a/Evaluator/Strategies/mixed_strategies_evaluator/tests/test_technical_analysis_strategy_evaluator.py
+++ b/Evaluator/Strategies/mixed_strategies_evaluator/tests/test_technical_analysis_strategy_evaluator.py
@@ -40,31 +40,31 @@ class TechnicalAnalysisStrategyEvaluatorTest(abstract_strategy_test.AbstractStra
 
     async def test_default_run(self):
         # market: -12.052505966587105
-        await self.run_test_default_run(-2.717)
+        await self.run_test_default_run(-2.718)
 
     async def test_slow_downtrend(self):
         # market: -12.052505966587105
         # market: -15.195702225633141
         # market: -29.12366137549725
         # market: -32.110091743119256
-        await self.run_test_slow_downtrend(-2.717, -4.584, -9.798, -12.499)
+        await self.run_test_slow_downtrend(-2.718, -4.584, -9.798, -12.562)
 
     async def test_sharp_downtrend(self):
         # market: -26.07183938094741
         # market: -32.1654501216545
-        await self.run_test_sharp_downtrend(-19.514, -13.323)
+        await self.run_test_sharp_downtrend(-19.514, -13.322)
 
     async def test_flat_markets(self):
         # market: -10.560669456066947
         # market: -3.401191658391241
         # market: -5.7854560064282765
         # market: -8.067940552016978
-        await self.run_test_flat_markets(-0.811, 0.733, -7.592, 8.305)
+        await self.run_test_flat_markets(-0.811, 0.733, -7.592, 8.319)
 
     async def test_slow_uptrend(self):
         # market: 17.203948364436457
         # market: 16.19613670133728
-        await self.run_test_slow_uptrend(3.895, 16.903)
+        await self.run_test_slow_uptrend(3.895, 16.862)
 
     async def test_sharp_uptrend(self):
         # market: 30.881852230166828

--- a/Evaluator/Strategies/move_signals_strategy_evaluator/tests/test_move_signals_strategy_evaluator.py
+++ b/Evaluator/Strategies/move_signals_strategy_evaluator/tests/test_move_signals_strategy_evaluator.py
@@ -47,19 +47,19 @@ class MoveSignalsStrategyEvaluatorTest(abstract_strategy_test.AbstractStrategyTe
         # market: -15.195702225633141
         # market: -29.12366137549725
         # market: -32.110091743119256
-        await self.run_test_slow_downtrend(-2.592, -2.347, -17.393, -15.889)
+        await self.run_test_slow_downtrend(-2.592, -2.347, -17.393, -15.761)
 
     async def test_sharp_downtrend(self):
         # market: -26.07183938094741
         # market: -32.1654501216545
-        await self.run_test_sharp_downtrend(-8.537, -10.317)
+        await self.run_test_sharp_downtrend(-8.538, -10.3)
 
     async def test_flat_markets(self):
         # market: -10.560669456066947
         # market: -3.401191658391241
         # market: -5.7854560064282765
         # market: -8.067940552016978
-        await self.run_test_flat_markets(0.953, 1.097, -8.131, -7.033)
+        await self.run_test_flat_markets(0.953, 1.097, -8.126, -7.038)
 
     async def test_slow_uptrend(self):
         # market: 17.203948364436457

--- a/Trading/Mode/daily_trading_mode/tests/test_daily_trading_mode_consumer.py
+++ b/Trading/Mode/daily_trading_mode/tests/test_daily_trading_mode_consumer.py
@@ -451,7 +451,7 @@ async def test_split_create_new_orders():
         assert adapted_order.trader == trader
         assert adapted_order.fee is None
         assert adapted_order.filled_price == 0
-        assert adapted_order.origin_quantity == 64625635.97358092
+        assert adapted_order.origin_quantity == 64625635.97358093
         assert adapted_order.filled_quantity == adapted_order.origin_quantity
         assert adapted_order.simulated is True
         assert adapted_order.linked_to is None
@@ -515,7 +515,7 @@ async def test_split_create_new_orders():
         assert adapted_order.trader == trader
         assert adapted_order.fee is None
         assert adapted_order.filled_price == 0
-        assert adapted_order.origin_quantity == 396851564266.65326
+        assert adapted_order.origin_quantity == 396851564266.6533
         assert adapted_order.filled_quantity == adapted_order.origin_quantity
         assert adapted_order.simulated is True
         assert adapted_order.linked_to is None


### PR DESCRIPTION
Migrate to decimal order adapter to prevent truncating order quantity when calling `check_and_adapt_order_details_if_necessary`
