### PR TITLE
[TradingModes] add custom order size

### DIFF
--- a/Trading/Mode/dip_analyser_trading_mode/dip_analyser_trading.py
+++ b/Trading/Mode/dip_analyser_trading_mode/dip_analyser_trading.py
@@ -29,6 +29,7 @@ import octobot_trading.enums as trading_enums
 import octobot_trading.constants as trading_constants
 import octobot_trading.errors as trading_errors
 import octobot_trading.personal_data as trading_personal_data
+import octobot_trading.modes.script_keywords as script_keywords
 import tentacles.Evaluator.Strategies as Strategies
 
 
@@ -43,7 +44,10 @@ class DipAnalyserTradingMode(trading_modes.AbstractTradingMode):
         Called right before starting the tentacle, should define all the tentacle's user inputs unless
         those are defined somewhere else.
         """
-        self.should_emit_trading_signals_user_input(inputs)
+        trading_modes.should_emit_trading_signals_user_input(self, inputs)
+
+        trading_modes.user_select_order_amount(self, inputs, include_sell=False)
+
         self.sell_orders_per_buy = self.UI.user_input(
             "sell_orders_count", commons_enums.UserInputTypes.INT, 3, inputs, min_val=1,
             title="Number of sell orders to create after each buy."
@@ -56,17 +60,17 @@ class DipAnalyserTradingMode(trading_modes.AbstractTradingMode):
         self.UI.user_input(
             DipAnalyserTradingModeConsumer.LIGHT_VOLUME_WEIGHT, commons_enums.UserInputTypes.FLOAT, 0.4, inputs,
             min_val=0, max_val=1,
-            title="Volume multiplier for the top sell order in a light price weight signal.",
+            title="Volume multiplier for a buy order on a light price weight signal.",
         )
         self.UI.user_input(
             DipAnalyserTradingModeConsumer.MEDIUM_VOLUME_WEIGHT, commons_enums.UserInputTypes.FLOAT, 0.7, inputs,
             min_val=0, max_val=1,
-            title="Volume multiplier for the top sell order in a medium price weight signal.",
+            title="Volume multiplier for a buy order on a medium price weight signal.",
         )
         self.UI.user_input(
             DipAnalyserTradingModeConsumer.HEAVY_VOLUME_WEIGHT, commons_enums.UserInputTypes.FLOAT, 1, inputs,
             min_val=0, max_val=1,
-            title="Volume multiplier for the top sell order in a heavy price weight signal.",
+            title="Volume multiplier for a buy order on a heavy price weight signal.",
         )
         self.UI.user_input(
             DipAnalyserTradingModeConsumer.LIGHT_PRICE_WEIGHT, commons_enums.UserInputTypes.FLOAT, 1.04, inputs,
@@ -207,7 +211,8 @@ class DipAnalyserTradingModeConsumer(trading_modes.AbstractTradingModeConsumer):
             base = symbol_util.parse_symbol(symbol).base
             created_orders = []
             orders_should_have_been_created = False
-            quantity = await self._get_buy_quantity_from_weight(volume_weight, max_buy_size, base)
+            ctx = script_keywords.get_base_context(self.trading_mode, symbol)
+            quantity = await self._get_buy_quantity_from_weight(ctx, volume_weight, max_buy_size, base)
             limit_price = trading_personal_data.decimal_adapt_price(symbol_market, self.get_limit_price(price))
             for order_quantity, order_price in trading_personal_data.decimal_check_and_adapt_order_details_if_necessary(
                     quantity,
@@ -286,11 +291,22 @@ class DipAnalyserTradingModeConsumer(trading_modes.AbstractTradingModeConsumer):
     def unregister_buy_order(self, order_id):
         self.sell_targets_by_order_id.pop(order_id, None)
 
-    async def _get_buy_quantity_from_weight(self, volume_weight, market_quantity, currency):
+    async def _get_buy_quantity_from_weight(self, ctx, volume_weight, market_quantity, currency):
         weighted_volume = self.VOLUME_WEIGH_TO_VOLUME_PERCENT[volume_weight]
         # high risk is making larger orders, low risk is making smaller ones
         risk_multiplier = 1 + ((self.exchange_manager.trader.risk - decimal.Decimal("0.5")) * self.RISK_VOLUME_MULTIPLIER)
         weighted_volume = min(weighted_volume * risk_multiplier, trading_constants.ONE)
+        # check configured quantity
+        if user_amount := trading_modes.get_user_selected_order_amount(self.trading_mode,
+                                                                       trading_enums.TradeOrderSide.BUY):
+            return await script_keywords.get_amount_from_input_amount(
+                context=ctx,
+                input_amount=user_amount,
+                side=trading_enums.TradeOrderSide.BUY.value,
+                reduce_only=False,
+                is_stop_order=False,
+                use_total_holding=False,
+            ) * weighted_volume
         traded_assets_count = self.get_number_of_traded_assets()
         if traded_assets_count == 1:
             return market_quantity * self.DEFAULT_FULL_VOLUME * weighted_volume

--- a/Trading/Mode/grid_trading_mode/grid_trading.py
+++ b/Trading/Mode/grid_trading_mode/grid_trading.py
@@ -48,14 +48,14 @@ class GridTradingMode(staggered_orders_trading.StaggeredOrdersTradingMode):
         those are defined somewhere else.
         """
         self.UI.user_input(self.CONFIG_PAIR_SETTINGS, commons_enums.UserInputTypes.OBJECT_ARRAY,
-                        self.trading_config.get(self.CONFIG_PAIR_SETTINGS, None), inputs,
-                        item_title="Pair configuration",
-                        other_schema_values={"minItems": 1, "uniqueItems": True},
-                        title="Configuration for each traded pairs.")
+                           self.trading_config.get(self.CONFIG_PAIR_SETTINGS, None), inputs,
+                           item_title="Pair configuration",
+                           other_schema_values={"minItems": 1, "uniqueItems": True},
+                           title="Configuration for each traded pairs.")
         self.UI.user_input(self.CONFIG_PAIR, commons_enums.UserInputTypes.TEXT, "BTC/USDT", inputs,
-                        other_schema_values={"minLength": 3, "pattern": "([a-zA-Z]|\\d){2,}\\/([a-zA-Z]|\\d){2,}"},
-                        parent_input_name=self.CONFIG_PAIR_SETTINGS,
-                        title="Name of the traded pair."),
+                           other_schema_values={"minLength": 3, "pattern": "([a-zA-Z]|\\d){2,}\\/([a-zA-Z]|\\d){2,}"},
+                           parent_input_name=self.CONFIG_PAIR_SETTINGS,
+                           title="Name of the traded pair."),
         self.UI.user_input(
             self.CONFIG_FLAT_SPREAD, commons_enums.UserInputTypes.FLOAT, 0.005, inputs,
             min_val=0, other_schema_values={"exclusiveMinimum": True},
@@ -86,7 +86,7 @@ class GridTradingMode(staggered_orders_trading.StaggeredOrdersTradingMode):
                   "to create that many orders.",
         )
         self.UI.user_input(
-            self.CONFIG_BUY_FUNDS, commons_enums.UserInputTypes.FLOAT, 0.005, inputs,
+            self.CONFIG_BUY_FUNDS, commons_enums.UserInputTypes.FLOAT, 0, inputs,
             min_val=0,
             parent_input_name=self.CONFIG_PAIR_SETTINGS,
             title="[Optional] Total buy funds: total funds to use for buy orders creation (in quote currency: USDT "
@@ -94,7 +94,7 @@ class GridTradingMode(staggered_orders_trading.StaggeredOrdersTradingMode):
                   "simultaneously in multiple traded pairs.",
         )
         self.UI.user_input(
-            self.CONFIG_SELL_FUNDS, commons_enums.UserInputTypes.FLOAT, 0.005, inputs,
+            self.CONFIG_SELL_FUNDS, commons_enums.UserInputTypes.FLOAT, 0, inputs,
             min_val=0,
             parent_input_name=self.CONFIG_PAIR_SETTINGS,
             title="[Optional] Total sell funds: total funds to use for sell orders creation (in base currency: "
@@ -102,14 +102,22 @@ class GridTradingMode(staggered_orders_trading.StaggeredOrdersTradingMode):
                   "currency simultaneously in multiple traded pairs.",
         )
         self.UI.user_input(
-            self.CONFIG_STARTING_PRICE, commons_enums.UserInputTypes.FLOAT, 0.005, inputs,
+            self.CONFIG_STARTING_PRICE, commons_enums.UserInputTypes.FLOAT, 0, inputs,
             min_val=0,
             parent_input_name=self.CONFIG_PAIR_SETTINGS,
             title="[Optional] Starting price: price to compute initial orders from. Set 0 to use current "
                   "exchange price during initial grid orders creation.",
         )
         self.UI.user_input(
-            self.CONFIG_SELL_VOLUME_PER_ORDER, commons_enums.UserInputTypes.FLOAT, 0.005, inputs,
+            self.CONFIG_BUY_VOLUME_PER_ORDER, commons_enums.UserInputTypes.FLOAT, 0, inputs,
+            min_val=0,
+            parent_input_name=self.CONFIG_PAIR_SETTINGS,
+            title="[Optional] Buy orders volume: volume of each buy order in quote currency. Set 0 to use all "
+                  "available base funds in portfolio (or total buy funds if set) to create orders with constant "
+                  "total order cost (price * volume).",
+        )
+        self.UI.user_input(
+            self.CONFIG_SELL_VOLUME_PER_ORDER, commons_enums.UserInputTypes.FLOAT, 0, inputs,
             min_val=0,
             parent_input_name=self.CONFIG_PAIR_SETTINGS,
             title="[Optional] Sell orders volume: volume of each sell order in quote currency. Set 0 to use all "
@@ -238,7 +246,7 @@ class GridTradingModeProducer(staggered_orders_trading.StaggeredOrdersTradingMod
 
     async def trigger_staggered_orders_creation(self):
         # reload configuration
-        await self.trading_mode.reload_config()
+        await self.trading_mode.reload_config(self.exchange_manager.bot_id)
         self._load_symbol_trading_config()
         self.read_config()
         if self.symbol_trading_config:

--- a/Trading/Mode/staggered_orders_trading_mode/staggered_orders_trading.py
+++ b/Trading/Mode/staggered_orders_trading_mode/staggered_orders_trading.py
@@ -119,14 +119,14 @@ class StaggeredOrdersTradingMode(trading_modes.AbstractTradingMode):
         those are defined somewhere else.
         """
         self.UI.user_input(self.CONFIG_PAIR_SETTINGS, commons_enums.UserInputTypes.OBJECT_ARRAY,
-                        self.trading_config.get(self.CONFIG_PAIR_SETTINGS, None), inputs,
-                        item_title="Pair configuration",
-                        other_schema_values={"minItems": 1, "uniqueItems": True},
-                        title="Configuration for each traded pairs.")
+                           self.trading_config.get(self.CONFIG_PAIR_SETTINGS, None), inputs,
+                           item_title="Pair configuration",
+                           other_schema_values={"minItems": 1, "uniqueItems": True},
+                           title="Configuration for each traded pairs.")
         self.UI.user_input(self.CONFIG_PAIR, commons_enums.UserInputTypes.TEXT, "BTC/USDT", inputs,
-                        other_schema_values={"minLength": 3, "pattern": "([a-zA-Z]|\\d){2,}\\/([a-zA-Z]|\\d){2,}"},
-                        parent_input_name=self.CONFIG_PAIR_SETTINGS,
-                        title="Name of the traded pair."),
+                           other_schema_values={"minLength": 3, "pattern": "([a-zA-Z]|\\d){2,}\\/([a-zA-Z]|\\d){2,}"},
+                           parent_input_name=self.CONFIG_PAIR_SETTINGS,
+                           title="Name of the traded pair."),
         self.UI.user_input(
             self.CONFIG_MODE, commons_enums.UserInputTypes.OPTIONS, StrategyModes.NEUTRAL.value, inputs,
             options=list(mode.value for mode in StrategyModes),

--- a/Trading/Mode/trading_view_signals_trading_mode/resources/TradingViewSignalsTradingMode.md
+++ b/Trading/Mode/trading_view_signals_trading_mode/resources/TradingViewSignalsTradingMode.md
@@ -20,10 +20,10 @@ REDUCE_ONLY=true
 
 Where:
 - `ORDER_TYPE` is the type of order (LIMIT or MARKET). Overrides the `Use market orders` parameter
-- `VOLUME` is the volume of the order in base asset (BTC for BTC/USDT)
+- `VOLUME` is the volume of the order in base asset (BTC for BTC/USDT) it can a flat amount (ex: `0.1` to trade 0.1 BTC on BTC/USD), a % of the total portfolio value (ex: `2%`) or a % of the available holdings (ex: `12a%`)
 - `PRICE` is the price of the limit order in quote asset (USDT for BTC/USDT)
 - `STOP_PRICE` is the price of the stop order to create (also requires the `PRICE` to be set to link it with a limit order)
-- `REDUCE_ONLY` when true, only reduce the current position (avoid accidental short position opening when reducing a long position). Only used in futures trading. Default is false
+- `REDUCE_ONLY` when true, only reduce the current position (avoid accidental short position opening when reducing a long position). ****Only used in futures trading. Default is false
 
 When not specified, orders volume and price are automatically computed based on the current 
 asset price and holdings.


### PR DESCRIPTION
requires https://github.com/Drakkar-Software/OctoBot-Trading/pull/771
enabled for all trading modes that were missing it, example with daily trading mode
![image](https://user-images.githubusercontent.com/9078616/203415857-32fce0e0-4407-46f6-9d63-c428e94dcf4a.png)
