### PR TITLE
[BinanceUsdM] add binance usd futures support

### DIFF
--- a/Trading/Exchange/binanceusdm/__init__.py
+++ b/Trading/Exchange/binanceusdm/__init__.py
@@ -1,0 +1,17 @@
+#  Drakkar-Software OctoBot-Tentacles
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+from .binanceusdm_exchange import BinanceUsdM

--- a/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
+++ b/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
@@ -215,7 +215,9 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
                 mode = trading_enums.PositionMode.HEDGE
             else:
                 raise ValueError("cant detect the PositionMode")
-            original_side = fixed[trading_enums.ExchangeConstantsPositionColumns.SIDE.value]
+            original_side = fixed[
+                trading_enums.ExchangeConstantsPositionColumns.SIDE.value
+            ]
             side = raw_position_info.get(self.POSITION_SIDE)
             try:
                 side = trading_enums.PositionSide(side.lower())
@@ -279,6 +281,7 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
 
     BINANCE_REDUCE_ONLY = "reduceOnly"
     BINANCE_TRIGGER_PRICE = "triggerPrice"
+    BINANCE_UPDATE_TIME = "updateTime"
 
     def fix_order(self, raw, **kwargs):
         fixed = super().fix_order(raw, **kwargs)
@@ -293,7 +296,15 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
                 self.BINANCE_TRIGGER_PRICE
             )
         self._adapt_order_type(fixed)
-
+        if not fixed[trading_enums.ExchangeConstantsOrderColumns.TIMESTAMP.value]:
+            if fixed["info"].get(self.BINANCE_UPDATE_TIME):
+                fixed[trading_enums.ExchangeConstantsOrderColumns.TIMESTAMP.value] = (
+                    int(fixed["info"][self.BINANCE_UPDATE_TIME]) / 1000
+                )
+            elif fixed["info"].get(self.BINANCE_TIME):
+                fixed[trading_enums.ExchangeConstantsOrderColumns.TIMESTAMP.value] = (
+                    int(fixed["info"][self.BINANCE_TIME]) / 1000
+                )
         return fixed
 
     def _adapt_order_type(self, fixed):

--- a/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
+++ b/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
@@ -30,6 +30,7 @@ class BinanceUsdM(exchanges.RestExchange):
     DESCRIPTION = ""
     MARK_PRICE_IN_TICKER = True
     FUNDING_IN_TICKER = True
+    SUPPORTS_ORDER_EDITING = False
 
     @classmethod
     def get_supported_exchange_types(cls) -> list:
@@ -186,28 +187,6 @@ class BinanceUsdM(exchanges.RestExchange):
             "_create_limit_trailing_stop_order is not implemented"
         )
 
-    async def edit_order(
-        self,
-        order_id: str,
-        order_type: trading_enums.TraderOrderType,
-        symbol: str,
-        quantity: decimal.Decimal,
-        price: decimal.Decimal,
-        stop_price: decimal.Decimal = None,
-        side: trading_enums.TradeOrderSide = None,
-        current_price: decimal.Decimal = None,
-        params: dict = None,
-    ):
-        # Binance futures doesnt have a api for editing orders
-        return await self.edit_order_by_replacing(
-            order_id=order_id,
-            order_type=order_type,
-            symbol=symbol,
-            quantity=quantity,
-            price=price,
-            stop_price=stop_price,
-            side=side,
-        )
 
 
 class BinanceUsdMAdapter(exchanges.CCXTAdapter):

--- a/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
+++ b/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
@@ -217,7 +217,6 @@ class BinanceUsdM(exchanges.RestExchange):
         )
 
 
-
 class BinanceUsdMAdapter(exchanges.CCXTAdapter):
     BINANCE_MODE = "hedged"
     POSITION_SIDE = "positionSide"
@@ -358,13 +357,10 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
 
     def fix_funding_rate(self, raw, **kwargs):
         fixed = super().fix_funding_rate(raw, **kwargs)
-        fixed[
-            trading_enums.ExchangeConstantsFundingColumns.NEXT_FUNDING_TIME.value
-        ] = fixed[self.NEXT_FUNDING_TIME]
-        fixed[trading_enums.ExchangeConstantsFundingColumns.LAST_FUNDING_TIME.value] = (
+        fixed[ccxt_enums.ExchangeFundingCCXTColumns.NEXT_FUNDING_TIME.value] = fixed[
+            self.NEXT_FUNDING_TIME
+        ]
+        fixed[ccxt_enums.ExchangeFundingCCXTColumns.LAST_FUNDING_TIME.value] = (
             fixed[self.NEXT_FUNDING_TIME] - self.DEFAULT_FUNDING_TIME
         )
-        fixed[trading_enums.ExchangeConstantsFundingColumns.FUNDING_RATE.value] = fixed[
-            ccxt_enums.ExchangeFundingCCXTColumns.FUNDING_RATE.value
-        ]
         return fixed

--- a/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
+++ b/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
@@ -1,0 +1,173 @@
+#  Drakkar-Software OctoBot-Tentacles
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+import decimal
+import octobot_trading.enums as enums
+import octobot_trading.exchanges as exchanges
+import octobot_trading.enums as trading_enums
+import octobot_trading.exchanges.connectors.ccxt.enums as ccxt_enums
+import octobot_trading.constants as constants
+
+
+class BinanceUsdM(exchanges.RestExchange):
+    DESCRIPTION = ""
+
+    MARK_PRICE_IN_TICKER = True
+    FUNDING_IN_TICKER = True
+
+    @classmethod
+    def get_supported_exchange_types(cls) -> list:
+        return [enums.ExchangeTypes.FUTURE]
+
+    def get_adapter_class(self):
+        return BinanceUsdMAdapter
+
+    @classmethod
+    def get_name(cls):
+        return "binanceusdm"
+
+    async def set_symbol_partial_take_profit_stop_loss(
+        self, symbol: str, inverse: bool, tp_sl_mode: enums.TakeProfitStopLossMode
+    ):
+        # no partial tp / sl - use limit and stop market instead
+        pass
+
+    async def _create_market_stop_loss_order(
+        self, symbol, quantity, price, side, current_price, params=None
+    ) -> dict:
+        raise NotImplementedError("_create_market_stop_loss_order is not implemented")
+
+    async def _create_limit_stop_loss_order(
+        self, symbol, quantity, price=None, side=None, params=None
+    ) -> dict:
+        raise NotImplementedError("_create_limit_stop_loss_order is not implemented")
+
+    async def _create_market_take_profit_order(
+        self, symbol, quantity, price=None, side=None, params=None
+    ) -> dict:
+        raise NotImplementedError("_create_market_take_profit_order is not implemented")
+
+    async def _create_limit_take_profit_order(
+        self, symbol, quantity, price=None, side=None, params=None
+    ) -> dict:
+        raise NotImplementedError("_create_limit_take_profit_order is not implemented")
+
+    async def _create_market_trailing_stop_order(
+        self, symbol, quantity, price=None, side=None, params=None
+    ) -> dict:
+        raise NotImplementedError(
+            "_create_market_trailing_stop_order is not implemented"
+        )
+
+    async def _create_limit_trailing_stop_order(
+        self, symbol, quantity, price=None, side=None, params=None
+    ) -> dict:
+        raise NotImplementedError(
+            "_create_limit_trailing_stop_order is not implemented"
+        )
+
+
+class BinanceUsdMAdapter(exchanges.CCXTAdapter):
+    BINANCE_MODE = "hedged"
+    POSITION_SIDE = "positionSide"
+
+    def parse_position(self, fixed, **kwargs):
+        # REALIZED_PNL, CLOSING_FEE, BANKRUPTCY_PRICE is not available in position
+        try:
+            raw_position_info = fixed.get(
+                ccxt_enums.ExchangePositionCCXTColumns.INFO.value
+            )
+            size = decimal.Decimal(
+                str(
+                    fixed.get(ccxt_enums.ExchangePositionCCXTColumns.CONTRACTS.value, 0)
+                )
+            )
+            # if size == constants.ZERO:
+            #     return {}  # Don't parse empty position
+
+            symbol = self.connector.get_pair_from_exchange(
+                fixed[ccxt_enums.ExchangePositionCCXTColumns.SYMBOL.value]
+            )
+            raw_mode = fixed.get(self.BINANCE_MODE)
+            if raw_mode is False:
+                mode = trading_enums.PositionMode.ONE_WAY
+            elif raw_mode is True:
+                mode = trading_enums.PositionMode.HEDGE
+            else:
+                raise ValueError("cant detect the PositionMode")
+            original_side = raw_position_info.get(self.POSITION_SIDE)
+            try:
+                side = trading_enums.PositionSide(original_side.lower())
+            except ValueError:
+                side = trading_enums.PositionSide.UNKNOWN
+            unrealized_pnl = self.safe_decimal(
+                fixed,
+                ccxt_enums.ExchangePositionCCXTColumns.UNREALIZED_PNL.value,
+                constants.ZERO,
+            )
+            liquidation_price = self.safe_decimal(
+                fixed,
+                ccxt_enums.ExchangePositionCCXTColumns.LIQUIDATION_PRICE.value,
+                constants.ZERO,
+            )
+            entry_price = self.safe_decimal(
+                fixed,
+                ccxt_enums.ExchangePositionCCXTColumns.ENTRY_PRICE.value,
+                constants.ZERO,
+            )
+            return {
+                trading_enums.ExchangeConstantsPositionColumns.SYMBOL.value: symbol,
+                trading_enums.ExchangeConstantsPositionColumns.TIMESTAMP.value: self.connector.client.safe_value(
+                    fixed, ccxt_enums.ExchangePositionCCXTColumns.TIMESTAMP.value, 0
+                ),
+                trading_enums.ExchangeConstantsPositionColumns.SIDE.value: side,
+                trading_enums.ExchangeConstantsPositionColumns.MARGIN_TYPE.value: trading_enums.TraderPositionType(
+                    fixed.get(ccxt_enums.ExchangePositionCCXTColumns.MARGIN_MODE.value)
+                ),
+                trading_enums.ExchangeConstantsPositionColumns.SIZE.value: size
+                if original_side == trading_enums.PositionSide.LONG.value
+                else -size,
+                trading_enums.ExchangeConstantsPositionColumns.SINGLE_CONTRACT_VALUE.value: self.safe_decimal(
+                    fixed,
+                    ccxt_enums.ExchangePositionCCXTColumns.CONTRACT_SIZE.value,
+                    constants.ONE,
+                ),
+                trading_enums.ExchangeConstantsPositionColumns.INITIAL_MARGIN.value: self.safe_decimal(
+                    fixed,
+                    ccxt_enums.ExchangePositionCCXTColumns.INITIAL_MARGIN.value,
+                    constants.ZERO,
+                ),
+                trading_enums.ExchangeConstantsPositionColumns.VALUE.value: self.safe_decimal(
+                    fixed,
+                    ccxt_enums.ExchangePositionCCXTColumns.NOTIONAL.value,
+                    constants.ZERO,
+                ),
+                trading_enums.ExchangeConstantsPositionColumns.LEVERAGE.value: self.safe_decimal(
+                    fixed,
+                    ccxt_enums.ExchangePositionCCXTColumns.LEVERAGE.value,
+                    constants.ONE,
+                ),
+                trading_enums.ExchangeConstantsPositionColumns.UNREALIZED_PNL.value: unrealized_pnl,
+                trading_enums.ExchangeConstantsPositionColumns.LIQUIDATION_PRICE.value: liquidation_price,
+                trading_enums.ExchangeConstantsPositionColumns.ENTRY_PRICE.value: entry_price,
+                trading_enums.ExchangeConstantsPositionColumns.CONTRACT_TYPE.value: self.connector.exchange_manager.exchange.get_contract_type(
+                    symbol
+                ),
+                trading_enums.ExchangeConstantsPositionColumns.POSITION_MODE.value: mode,
+            }
+        except KeyError as e:
+            self.logger.error(f"Fail to parse position dict ({e})")
+        return fixed

--- a/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
+++ b/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
@@ -313,7 +313,7 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
         fixed[
             trading_enums.ExchangeConstantsOrderColumns.REDUCE_ONLY.value
         ] = order_info.get(self.BINANCE_REDUCE_ONLY, False)
-        # stop orders ise triggerPrice
+        # stop orders use triggerPrice
         if not fixed.get(trading_enums.ExchangeConstantsOrderColumns.PRICE.value):
             fixed[trading_enums.ExchangeConstantsOrderColumns.PRICE.value] = fixed.get(
                 self.BINANCE_TRIGGER_PRICE
@@ -329,7 +329,7 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
     def _adapt_order_type(self, fixed):
         if (
             fixed[trading_enums.ExchangeConstantsOrderColumns.REDUCE_ONLY.value]
-            and trading_enums.TradeOrderType.STOP_MARKET.value
+            and trading_enums.TradeOrderType.CONDITIONAL_MARKET.value
             == fixed[trading_enums.ExchangeConstantsOrderColumns.TYPE.value]
         ):
             # stop loss are not tagged as such by ccxt, force it

--- a/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
+++ b/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
@@ -72,8 +72,42 @@ class BinanceUsdM(exchanges.RestExchange):
         # no partial tp / sl - use limit and stop market instead
         pass
 
+    async def _create_limit_buy_order(
+        self, symbol, quantity, price=None, reduce_only: bool = False, params=None
+    ) -> dict:
+        if reduce_only:
+            params = params or {}
+            params["reduceOnly"] = True
+        return await super()._create_limit_buy_order(
+            symbol=symbol,
+            quantity=quantity,
+            price=price,
+            reduce_only=reduce_only,
+            params=params,
+        )
+
+    async def _create_limit_sell_order(
+        self, symbol, quantity, price=None, reduce_only: bool = False, params=None
+    ) -> dict:
+        if reduce_only:
+            params = params or {}
+            params["reduceOnly"] = True
+        return await super()._create_limit_sell_order(
+            symbol=symbol,
+            quantity=quantity,
+            price=price,
+            reduce_only=reduce_only,
+            params=params,
+        )
+
     async def _create_market_stop_loss_order(
-        self, symbol, quantity, price, side, current_price, params=None
+        self,
+        symbol,
+        quantity,
+        price,
+        side,
+        current_price,
+        params=None,
     ) -> dict:
         params = params or {}
         params["reduceOnly"] = True
@@ -87,7 +121,13 @@ class BinanceUsdM(exchanges.RestExchange):
         )
 
     async def _create_limit_stop_loss_order(
-        self, symbol, quantity, price, stop_price, side, params=None
+        self,
+        symbol,
+        quantity,
+        price,
+        stop_price,
+        side,
+        params=None,
     ) -> dict:
         params = params or {}
         params["reduceOnly"] = True
@@ -101,24 +141,46 @@ class BinanceUsdM(exchanges.RestExchange):
         )
 
     async def _create_market_take_profit_order(
-        self, symbol, quantity, price=None, side=None, params=None
+        self,
+        symbol,
+        quantity,
+        price=None,
+        side=None,
+        params=None,
     ) -> dict:
         raise NotImplementedError("_create_market_take_profit_order is not implemented")
 
     async def _create_limit_take_profit_order(
-        self, symbol, quantity, price=None, side=None, params=None
+        self,
+        symbol,
+        quantity,
+        price=None,
+        side=None,
+        params=None,
     ) -> dict:
         raise NotImplementedError("_create_limit_take_profit_order is not implemented")
 
     async def _create_market_trailing_stop_order(
-        self, symbol, quantity, price=None, side=None, params=None
+        self,
+        symbol,
+        quantity,
+        price=None,
+        side=None,
+        reduce_only: bool = False,
+        params=None,
     ) -> dict:
         raise NotImplementedError(
             "_create_market_trailing_stop_order is not implemented"
         )
 
     async def _create_limit_trailing_stop_order(
-        self, symbol, quantity, price=None, side=None, params=None
+        self,
+        symbol,
+        quantity,
+        price=None,
+        side=None,
+        reduce_only: bool = False,
+        params=None,
     ) -> dict:
         raise NotImplementedError(
             "_create_limit_trailing_stop_order is not implemented"

--- a/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
+++ b/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
@@ -70,8 +70,9 @@ class BinanceUsdM(exchanges.RestExchange):
         inverse: bool,
         tp_sl_mode: trading_enums.TakeProfitStopLossMode,
     ):
-        # no partial tp / sl - use limit and stop market instead
-        pass
+        # no partial tp / sl mode for this exchange
+        # it is already able to place partial limit and stop market
+        raise NotImplementedError
 
     async def _create_limit_buy_order(
         self, symbol, quantity, price=None, reduce_only: bool = False, params=None
@@ -204,9 +205,6 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
                     fixed.get(ccxt_enums.ExchangePositionCCXTColumns.CONTRACTS.value, 0)
                 )
             )
-            # if size == constants.ZERO:
-            #     return {}  # Don't parse empty position
-
             symbol = self.connector.get_pair_from_exchange(
                 fixed[ccxt_enums.ExchangePositionCCXTColumns.SYMBOL.value]
             )

--- a/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
+++ b/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
@@ -186,6 +186,29 @@ class BinanceUsdM(exchanges.RestExchange):
             "_create_limit_trailing_stop_order is not implemented"
         )
 
+    async def edit_order(
+        self,
+        order_id: str,
+        order_type: trading_enums.TraderOrderType,
+        symbol: str,
+        quantity: decimal.Decimal,
+        price: decimal.Decimal,
+        stop_price: decimal.Decimal = None,
+        side: trading_enums.TradeOrderSide = None,
+        current_price: decimal.Decimal = None,
+        params: dict = None,
+    ):
+        # Binance futures doesnt have a api for editing orders
+        return await self.edit_order_by_replacing(
+            order_id=order_id,
+            order_type=order_type,
+            symbol=symbol,
+            quantity=quantity,
+            price=price,
+            stop_price=stop_price,
+            side=side,
+        )
+
 
 class BinanceUsdMAdapter(exchanges.CCXTAdapter):
     BINANCE_MODE = "hedged"
@@ -300,10 +323,6 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
             if fixed["info"].get(self.BINANCE_UPDATE_TIME):
                 fixed[trading_enums.ExchangeConstantsOrderColumns.TIMESTAMP.value] = (
                     int(fixed["info"][self.BINANCE_UPDATE_TIME]) / 1000
-                )
-            elif fixed["info"].get(self.BINANCE_TIME):
-                fixed[trading_enums.ExchangeConstantsOrderColumns.TIMESTAMP.value] = (
-                    int(fixed["info"][self.BINANCE_TIME]) / 1000
                 )
         return fixed
 

--- a/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
+++ b/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
@@ -264,7 +264,7 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
             return {
                 trading_enums.ExchangeConstantsPositionColumns.SYMBOL.value: symbol,
                 trading_enums.ExchangeConstantsPositionColumns.SIDE.value: side,
-                trading_enums.ExchangeConstantsPositionColumns.MARGIN_TYPE.value: trading_enums.TraderPositionType(
+                trading_enums.ExchangeConstantsPositionColumns.MARGIN_TYPE.value: trading_enums.MarginType(
                     fixed.get(ccxt_enums.ExchangePositionCCXTColumns.MARGIN_MODE.value)
                 ),
                 trading_enums.ExchangeConstantsPositionColumns.SIZE.value: size
@@ -346,6 +346,13 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
 
     def fix_ticker(self, raw, **kwargs):
         fixed = super().fix_ticker(raw, **kwargs)
+        fixed[trading_enums.ExchangeConstantsMarkPriceColumns.MARK_PRICE.value] = fixed[
+            self.MARK_PRICE
+        ]
+        return fixed
+
+    def fix_funding_rate(self, raw, **kwargs):
+        fixed = super().fix_funding_rate(raw, **kwargs)
         fixed[
             trading_enums.ExchangeConstantsFundingColumns.NEXT_FUNDING_TIME.value
         ] = fixed[self.NEXT_FUNDING_TIME]
@@ -354,8 +361,5 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
         )
         fixed[trading_enums.ExchangeConstantsFundingColumns.FUNDING_RATE.value] = fixed[
             ccxt_enums.ExchangeFundingCCXTColumns.FUNDING_RATE.value
-        ]
-        fixed[trading_enums.ExchangeConstantsMarkPriceColumns.MARK_PRICE.value] = fixed[
-            self.MARK_PRICE
         ]
         return fixed

--- a/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
+++ b/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
@@ -215,9 +215,10 @@ class BinanceUsdMAdapter(exchanges.CCXTAdapter):
                 mode = trading_enums.PositionMode.HEDGE
             else:
                 raise ValueError("cant detect the PositionMode")
-            original_side = raw_position_info.get(self.POSITION_SIDE)
+            original_side = fixed[trading_enums.ExchangeConstantsPositionColumns.SIDE.value]
+            side = raw_position_info.get(self.POSITION_SIDE)
             try:
-                side = trading_enums.PositionSide(original_side.lower())
+                side = trading_enums.PositionSide(side.lower())
             except ValueError:
                 side = trading_enums.PositionSide.UNKNOWN
             unrealized_pnl = self.safe_decimal(

--- a/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
+++ b/Trading/Exchange/binanceusdm/binanceusdm_exchange.py
@@ -102,6 +102,34 @@ class BinanceUsdM(exchanges.RestExchange):
             params=params,
         )
 
+    async def _create_limit_buy_order(
+        self, symbol, quantity, price=None, reduce_only: bool = False, params=None
+    ) -> dict:
+        if reduce_only:
+            params = params or {}
+            params["reduceOnly"] = True
+        return await super()._create_limit_buy_order(
+            symbol=symbol,
+            quantity=quantity,
+            price=price,
+            reduce_only=reduce_only,
+            params=params,
+        )
+
+    async def _create_limit_sell_order(
+        self, symbol, quantity, price=None, reduce_only: bool = False, params=None
+    ) -> dict:
+        if reduce_only:
+            params = params or {}
+            params["reduceOnly"] = True
+        return await super()._create_limit_sell_order(
+            symbol=symbol,
+            quantity=quantity,
+            price=price,
+            reduce_only=reduce_only,
+            params=params,
+        )
+
     async def _create_market_stop_loss_order(
         self,
         symbol,

--- a/Trading/Exchange/binanceusdm/metadata.json
+++ b/Trading/Exchange/binanceusdm/metadata.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.2.0",
+  "origin_package": "OctoBot-Default-Tentacles",
+  "tentacles": ["BinanceUsdM"],
+  "tentacles-requirements": []
+}

--- a/Trading/Exchange/binanceusdm/resources/binanceusdm.md
+++ b/Trading/Exchange/binanceusdm/resources/binanceusdm.md
@@ -1,0 +1,1 @@
+Binance-USD-M is a FuturesExchange adaptation for Binance exchange using the REST API. 

--- a/Trading/Exchange/binanceusdm/tests/__init__.py
+++ b/Trading/Exchange/binanceusdm/tests/__init__.py
@@ -1,0 +1,15 @@
+#  Drakkar-Software OctoBot-Tentacles
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.

--- a/Trading/Exchange/binanceusdm/tests/test_sandbox.py
+++ b/Trading/Exchange/binanceusdm/tests/test_sandbox.py
@@ -1,0 +1,54 @@
+#  Drakkar-Software OctoBot-Tentacles
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+import os
+
+import pytest
+
+import octobot_commons.tests as commons_tests
+import octobot_commons.constants as commons_constants
+import octobot_trading.util.test_tools.spot_rest_exchange_test_tools as spot_rest_exchange_test_tools
+import octobot_commons.configuration as configuration
+from ...binanceusdm import BinanceUsdM
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+
+async def _test_futures_rest():
+    config = commons_tests.load_test_config()
+    config[commons_constants.CONFIG_EXCHANGES][BinanceUsdM.get_name()] = {
+        commons_constants.CONFIG_EXCHANGE_KEY: configuration.encrypt(
+            os.getenv(f"{BinanceUsdM.get_name()}_API_KEY".upper())
+        ).decode(),
+        commons_constants.CONFIG_EXCHANGE_SECRET: configuration.encrypt(
+            os.getenv(f"{BinanceUsdM.get_name()}_API_SECRET".upper())
+        ).decode(),
+    }
+    config[commons_constants.CONFIG_TRADER][
+        commons_constants.CONFIG_ENABLED_OPTION
+    ] = True
+    config[commons_constants.CONFIG_SIMULATOR][
+        commons_constants.CONFIG_ENABLED_OPTION
+    ] = False
+
+    test_tools = spot_rest_exchange_test_tools.SpotRestExchangeTests(
+        config=config, exchange_name=BinanceUsdM.get_name()
+    )
+    test_tools.expected_crypto_in_balance = ["USDT"]
+    await test_tools.initialize()
+    await test_tools.run(symbol="BTC/USDT:USDT")
+    await test_tools.stop()
+    await test_tools.test_all_callback_triggered()


### PR DESCRIPTION
so far it seems to work very well

requires: https://github.com/Drakkar-Software/OctoBot-Trading/pull/820

edit:
One thing to note is the get_price_ticker, its fetching funding rate as well, to get funding rate and mark_price.
Once there is way to set MARK_PRICE_IN_FUNDING_RATE and FUNDING_RATE_IN_FUNDING_RATE, the get_price_ticker method can be removed


Im not using the mark price in the position, as the mark price is only available once you have placed at least one (unfilled limit) order