### PR TITLE
[CreateOrder] add reduce only parameter (futures tentacles must implement it)

### DIFF
--- a/Trading/Exchange/binance/binance_exchange.py
+++ b/Trading/Exchange/binance/binance_exchange.py
@@ -54,12 +54,12 @@ class Binance(exchanges.RestExchange):
     async def create_order(self, order_type: trading_enums.TraderOrderType, symbol: str, quantity: decimal.Decimal,
                            price: decimal.Decimal = None, stop_price: decimal.Decimal = None,
                            side: trading_enums.TradeOrderSide = None, current_price: decimal.Decimal = None,
-                           params: dict = None):
+                           reduce_only: bool = False, params: dict = None):
         return await self._ensure_order_completeness(
             await super().create_order(order_type, symbol, quantity,
                                        price=price, stop_price=stop_price,
                                        side=side, current_price=current_price,
-                                       params=params),
+                                       reduce_only=reduce_only, params=params),
             symbol
         )
 

--- a/Trading/Exchange/bitget/bitget_exchange.py
+++ b/Trading/Exchange/bitget/bitget_exchange.py
@@ -41,7 +41,7 @@ class Bitget(exchanges.RestExchange):
     async def create_order(self, order_type: trading_enums.TraderOrderType, symbol: str, quantity: decimal.Decimal,
                            price: decimal.Decimal = None, stop_price: decimal.Decimal = None,
                            side: trading_enums.TradeOrderSide = None, current_price: decimal.Decimal = None,
-                           params: dict = None) -> typing.Optional[dict]:
+                           reduce_only: bool = False, params: dict = None) -> typing.Optional[dict]:
         # tell ccxt to use amount as provided and not to compute it by multiplying it by price which is done here
         # (price should not be sent to market orders). Only used for buy market orders
         self.connector.add_options({"createMarketBuyOrderRequiresPrice": False})
@@ -55,7 +55,7 @@ class Bitget(exchanges.RestExchange):
         return await super().create_order(order_type, symbol, quantity,
                                           price=price, stop_price=stop_price,
                                           side=side, current_price=current_price,
-                                          params=params)
+                                          reduce_only=reduce_only, params=params)
 
     def get_market_status(self, symbol, price_example=None, with_fixer=True):
         return self.get_fixed_market_status(symbol, price_example=price_example, with_fixer=with_fixer,

--- a/Trading/Exchange/coinex/coinex_exchange.py
+++ b/Trading/Exchange/coinex/coinex_exchange.py
@@ -50,7 +50,7 @@ class Coinex(exchanges.RestExchange):
     async def create_order(self, order_type: trading_enums.TraderOrderType, symbol: str, quantity: decimal.Decimal,
                            price: decimal.Decimal = None, stop_price: decimal.Decimal = None,
                            side: trading_enums.TradeOrderSide = None, current_price: decimal.Decimal = None,
-                           params: dict = None) -> typing.Optional[dict]:
+                           reduce_only: bool = False, params: dict = None) -> typing.Optional[dict]:
         # tell ccxt to use amount as provided and not to compute it by multiplying it by price which is done here
         # (price should not be sent to market orders). Only used for buy market orders
         self.connector.add_options({"createMarketBuyOrderRequiresPrice": False})
@@ -61,9 +61,9 @@ class Coinex(exchanges.RestExchange):
                                                           f"market orders as quantity is in quote currency")
             quantity = quantity * price
         return await super().create_order(order_type, symbol, quantity,
-                                          price=price, stop_price=stop_price,
-                                          side=side, current_price=current_price,
-                                          params=params)
+                                         price=price, stop_price=stop_price,
+                                         side=side, current_price=current_price,
+                                         reduce_only=reduce_only, params=params)
 
     def _fix_limit(self, limit: int) -> int:
         return min(self.MAX_PAGINATION_LIMIT, limit) if limit else limit

--- a/Trading/Exchange/huobi/huobi_exchange.py
+++ b/Trading/Exchange/huobi/huobi_exchange.py
@@ -37,7 +37,7 @@ class Huobi(exchanges.RestExchange):
     async def create_order(self, order_type: trading_enums.TraderOrderType, symbol: str, quantity: decimal.Decimal,
                            price: decimal.Decimal = None, stop_price: decimal.Decimal = None,
                            side: trading_enums.TradeOrderSide = None, current_price: decimal.Decimal = None,
-                           params: dict = None) -> typing.Optional[dict]:
+                           reduce_only: bool = False, params: dict = None) -> typing.Optional[dict]:
         # tell ccxt to use amount as provided and not to compute it by multiplying it by price which is done here
         # (price should not be sent to market orders). Only used for buy market orders
         self.connector.add_options({"createMarketBuyOrderRequiresPrice": False})
@@ -51,7 +51,7 @@ class Huobi(exchanges.RestExchange):
         return await super().create_order(order_type, symbol, quantity,
                                           price=price, stop_price=stop_price,
                                           side=side, current_price=current_price,
-                                          params=params)
+                                          reduce_only=reduce_only, params=params)
 
 
 class HuobiCCXTAdapter(exchanges.CCXTAdapter):


### PR DESCRIPTION
requires PR in trading -> [CCXT] add reduce only to create order (future exchange tentacles must implement it)
requires https://github.com/Drakkar-Software/OctoBot-Trading/pull/814