### PR TITLE
[Backtesting] support multi exchange backtestings

### DIFF
--- a/Services/Interfaces/web_interface/controllers/backtesting.py
+++ b/Services/Interfaces/web_interface/controllers/backtesting.py
@@ -19,6 +19,7 @@ import werkzeug
 
 import octobot_commons.time_frame_manager as time_frame_manager
 import octobot_commons.constants as commons_constants
+import octobot_backtesting.constants as backtesting_constants
 
 import tentacles.Services.Interfaces.web_interface as web_interface
 import tentacles.Services.Interfaces.web_interface.login as login
@@ -59,13 +60,21 @@ def backtesting():
                 data = flask.request.get_json()
                 source = flask.request.args["source"]
                 auto_stop = flask.request.args.get("auto_stop", False)
-                exchange_id = data.get("exchange_id", None)
+                data_sources = data.get("data_sources", None)
+                if data_sources:
+                    if backtesting_constants.CONFIG_CURRENT_BOT_DATA in data_sources:
+                        data_sources = [backtesting_constants.CONFIG_CURRENT_BOT_DATA]
+                else:
+                   data_sources = [data.get("data_source", backtesting_constants.CONFIG_CURRENT_BOT_DATA) ]
+                exchange_ids = data.get("exchange_ids", None)
+                if not exchange_ids:
+                    exchange_ids = [data.get("exchange_id", None)]
                 trading_type = data.get("exchange_type", None)
                 portfolio = data.get("portfolio", None)
                 reset_tentacle_config = flask.request.args.get("reset_tentacle_config", False)
                 success, reply = models.start_backtesting_using_current_bot_data(
-                    data.get("data_source", models.CURRENT_BOT_DATA),
-                    exchange_id,
+                    data_sources,
+                    exchange_ids,
                     source,
                     reset_tentacle_config,
                     start_timestamp=data.get("start_timestamp", None),

--- a/Services/Interfaces/web_interface/enums.py
+++ b/Services/Interfaces/web_interface/enums.py
@@ -28,3 +28,11 @@ class PriceStrings(enum.Enum):
 class TabsLocation(enum.Enum):
     START = "start"
     END = "end"
+
+
+class DataCollectorsStatus(enum.Enum):
+    FINISHED= "finished"
+    STARTING= "starting"
+    COLLECTING= "collecting"
+    NOT_STARTED = "not started"
+    

--- a/Services/Interfaces/web_interface/models/__init__.py
+++ b/Services/Interfaces/web_interface/models/__init__.py
@@ -31,7 +31,6 @@ from tentacles.Services.Interfaces.web_interface.models import web_interface_tab
 
 
 from tentacles.Services.Interfaces.web_interface.models.backtesting import (
-    CURRENT_BOT_DATA,
     get_full_candle_history_exchange_list,
     get_other_history_exchange_list,
     get_data_files_with_description,
@@ -398,7 +397,6 @@ __all__ = [
     "get_portfolio_historical_values",
     "has_pnl_history",
     "get_pnl_history",
-    "CURRENT_BOT_DATA",
     "get_full_candle_history_exchange_list",
     "get_other_history_exchange_list",
     "change_reference_market_on_config_currencies",


### PR DESCRIPTION
adds support for multi exchange backtests (see octo-ui2 dev branch as an example implementation)

requires:
https://github.com/Drakkar-Software/OctoBot-Trading/pull/847
https://github.com/Drakkar-Software/OctoBot-Backtesting/pull/172
https://github.com/Drakkar-Software/OctoBot/pull/2246