### PR TITLE
[WebInterface] improve md screen display

### DIFF
--- a/Services/Interfaces/web_interface/templates/layout.html
+++ b/Services/Interfaces/web_interface/templates/layout.html
@@ -102,7 +102,7 @@
         {% set show_nab_bar = show_nab_bar|default(True) -%}
 
         {% if show_nab_bar %}
-            <nav class="navbar navbar-expand-md navbar-dark sticky-top py-0 py-md-2" id="main-nav-bar">
+            <nav class="navbar navbar-expand-lg navbar-dark sticky-top py-0 py-md-2" id="main-nav-bar">
                 <div class="navbar-collapse collapse w-100 order-1 order-md-0 dual-collapse2">
                     <ul class="navbar-nav mr-auto" id="main-nav-left-part">
                         <li class="nav-item mx-1 px-0 my-auto {% if 'home' == active_page %} active{% endif %}">
@@ -122,7 +122,9 @@
                         </li>
                         {% if are_automations_enabled %}
                         <li class="nav-item mx-1 px-0 my-auto {% if 'automations' == active_page %} active{% endif %}">
-                            <a class="nav-link" href="{{ url_for('automations') }}">Automations</a>
+                            <a class="nav-link" href="{{ url_for('automations') }}" aria-label="Logs">
+                                <i class="fa-solid fa-repeat" data-toggle="tooltip" data-placement="top" title="Automations"></i>
+                                <span class="d-none d-xl-inline">Automations</span></a>
                         </li>
                         {% endif %}
                         {% for plugin_tab in get_plugin_tabs(TAB_START) %}


### PR DESCRIPTION
md:
![image](https://user-images.githubusercontent.com/9078616/225641849-3a99d359-9637-44a3-8b3a-a26b22024a43.png)
lg:
![image](https://user-images.githubusercontent.com/9078616/225641722-e43e6715-1a32-4ab2-85aa-8bbb1d7818c2.png)
xl:
![image](https://user-images.githubusercontent.com/9078616/225641774-41a21b1b-4000-4f62-ab46-6a2a1f164f26.png)

(fix navbar elements overflowing in md and lg display)