### PR TITLE
Tweak graphs on dashboard

### DIFF
--- a/Services/Interfaces/web_interface/static/js/common/candlesticks.js
+++ b/Services/Interfaces/web_interface/static/js/common/candlesticks.js
@@ -261,7 +261,7 @@ function create_layout(graph_title){
             b: 40,
             l: 60
         },
-        showlegend: true,
+        showlegend: false,
         xaxis: {
             autorange: true,
             domain: [0, 1],
@@ -377,7 +377,7 @@ function create_or_update_candlestick_graph(element_id, symbol_price_data, symbo
 
         const data = [volume_trace, price_trace, real_trader_trades, simulator_trades];
         const plotlyConfig = {
-            scrollZoom: true,
+            scrollZoom: false,
             modeBarButtonsToRemove: ["select2d", "lasso2d", "toggleSpikelines"],
             responsive: true,
             showEditInChartStudio: true,


### PR DESCRIPTION
-set showlegend to "false" (not really necessary and takes up precious screen space)
-set scrollZoom to "false" (less accidental zooming while scrolling page)