### PR TITLE
[Evaluators] disable hot timeframe change

### DIFF
--- a/Evaluator/RealTime/instant_fluctuations_evaluator/instant_fluctuations.py
+++ b/Evaluator/RealTime/instant_fluctuations_evaluator/instant_fluctuations.py
@@ -58,10 +58,11 @@ class InstantFluctuationsEvaluator(evaluators.RealTimeEvaluator):
         Called right before starting the tentacle, should define all the tentacle's user inputs unless
         those are defined somewhere else.
         """
-        self.time_frame = self.UI.user_input(commons_constants.CONFIG_TIME_FRAME, commons_enums.UserInputTypes.OPTIONS,
-                                             commons_enums.TimeFrames.ONE_MINUTE.value,
-                                             inputs, options=[tf.value for tf in commons_enums.TimeFrames],
-                                             title="Time frame: The time frame to observe in order to spot changes.")
+        self.time_frame = self.time_frame or \
+            self.UI.user_input(commons_constants.CONFIG_TIME_FRAME, commons_enums.UserInputTypes.OPTIONS,
+                               commons_enums.TimeFrames.ONE_MINUTE.value,
+                               inputs, options=[tf.value for tf in commons_enums.TimeFrames],
+                               title="Time frame: The time frame to observe in order to spot changes.")
         self.VOLUME_HAPPENING_THRESHOLD = 1 + self.UI.user_input(
             self.VOLUME_THRESHOLD_KEY, commons_enums.UserInputTypes.FLOAT, 400, inputs, min_val=0,
             title="Volume threshold: volume difference in percent from which to trigger a notification."
@@ -193,10 +194,11 @@ class InstantMAEvaluator(evaluators.RealTimeEvaluator):
         Called right before starting the tentacle, should define all the tentacle's user inputs unless
         those are defined somewhere else.
         """
-        self.time_frame = self.UI.user_input(commons_constants.CONFIG_TIME_FRAME, commons_enums.UserInputTypes.OPTIONS,
-                                          commons_enums.TimeFrames.ONE_MINUTE.value,
-                                          inputs, options=[tf.value for tf in commons_enums.TimeFrames],
-                                          title="Time frame: The time frame to observe in order to spot changes.")
+        self.time_frame = self.time_frame or \
+            self.UI.user_input(commons_constants.CONFIG_TIME_FRAME, commons_enums.UserInputTypes.OPTIONS,
+                               commons_enums.TimeFrames.ONE_MINUTE.value,
+                               inputs, options=[tf.value for tf in commons_enums.TimeFrames],
+                               title="Time frame: The time frame to observe in order to spot changes.")
         self.period = self.UI.user_input("period", commons_enums.UserInputTypes.INT, 6, inputs,
                                       min_val=1, title="Period: the EMA period length to use.")
 

--- a/Evaluator/Social/trends_evaluator/trends.py
+++ b/Evaluator/Social/trends_evaluator/trends.py
@@ -34,12 +34,12 @@ class GoogleTrendsEvaluator(evaluators.SocialEvaluator):
         self.relevant_history_months = 3
 
     def init_user_inputs(self, inputs: dict) -> None:
-        self.refresh_rate_seconds = self.UI.user_input(commons_constants.CONFIG_REFRESH_RATE,
-                                                    commons_enums.UserInputTypes.INT,
-                                                    self.refresh_rate_seconds, inputs, min_val=1,
-                                                    title="Seconds between each re-evaluation "
-                                                          "(do not set too low because google has a low "
-                                                          "monthly rate limit).")
+        self.refresh_rate_seconds = self.refresh_rate_seconds or \
+            self.UI.user_input(commons_constants.CONFIG_REFRESH_RATE,
+                               commons_enums.UserInputTypes.INT,
+                               self.refresh_rate_seconds, inputs, min_val=1,
+                               title="Seconds between each re-evaluation (do not set too low because google has a low "
+                                     "monthly rate limit).")
         self.relevant_history_months = self.UI.user_input(services_constants.CONFIG_TREND_HISTORY_TIME,
                                                        commons_enums.UserInputTypes.INT,
                                                        self.relevant_history_months, inputs, min_val=3, max_val=3,

--- a/Evaluator/Strategies/dip_analyser_strategy_evaluator/dip_analyser_strategy.py
+++ b/Evaluator/Strategies/dip_analyser_strategy_evaluator/dip_analyser_strategy.py
@@ -45,7 +45,7 @@ class DipAnalyserStrategyEvaluator(evaluators.StrategyEvaluator):
         Called right before starting the tentacle, should define all the tentacle's user inputs unless
         those are defined somewhere else.
         """
-        self.evaluation_time_frame = commons_enums.TimeFrames(
+        self.evaluation_time_frame = self.evaluation_time_frame or commons_enums.TimeFrames(
             self.UI.user_input(
                 evaluator_constants.STRATEGIES_REQUIRED_TIME_FRAME,
                 commons_enums.UserInputTypes.MULTIPLE_OPTIONS,


### PR DESCRIPTION
can't change timeframes in live mode as other timeframes won't be available (require restart)