### PR TITLE
[WebInterface] fix coingecko ssl issue

### DIFF
--- a/Services/Interfaces/web_interface/models/configuration.py
+++ b/Services/Interfaces/web_interface/models/configuration.py
@@ -1141,7 +1141,8 @@ async def _fetch_currency_logo(session, data_provider, currency_id):
 
 
 async def _fetch_missing_currency_logos(data_provider, currency_ids):
-    async with aiohttp_util.ssl_fallback_aiohttp_client_session("https://coingecko.com") as session:
+    # always use certify_aiohttp_client_session to avoid triggering rate limit with test request
+    async with aiohttp_util.certify_aiohttp_client_session() as session:
         await asyncio.gather(
             *(
                 _fetch_currency_logo(session, data_provider, currency_id)


### PR DESCRIPTION
issue is that for some users, coingecko.com works but not api.coingecko.com.
requires https://github.com/Drakkar-Software/OctoBot-Commons/pull/426