### PR TITLE
[WebInterface] improve new version notification

### DIFF
--- a/Services/Interfaces/web_interface/controllers/home.py
+++ b/Services/Interfaces/web_interface/controllers/home.py
@@ -87,6 +87,9 @@ def register(blueprint):
                 sandbox_exchanges=sandbox_exchanges,
                 display_ph_launch=display_ph_launch,
                 is_launching=is_launching,
+                latest_release_url=f"{octobot_commons.constants.GITHUB_BASE_URL}/"
+                                   f"{octobot_commons.constants.GITHUB_ORGANISATION}/"
+                                   f"{constants.PROJECT_NAME}/releases/latest",
             )
         else:
             return flask.redirect(flask.url_for("terms"))

--- a/Services/Interfaces/web_interface/templates/index.html
+++ b/Services/Interfaces/web_interface/templates/index.html
@@ -25,7 +25,15 @@
     {% endif %}
     {% if not IS_CLOUD %}
     <div class="d-none alert alert-success text-center my-2" role="alert">
-        <h5 class="d-none d-sm-inline"><span class="d-none d-md-inline"><i class="far fa-bell"></i> Good news ! </span>OctoBot version <span update-url="{{ url_for('api.upgrade_version') }}" id="upgradeVersion"></span> is available.</h5><button route="{{ url_for('commands', cmd='update') }}" type="button" class="btn btn-outline-primary waves-effect">Upgrade now <i class="fas fa-cloud-download-alt"></i></button>
+        <h5 class="d-none d-sm-inline">
+            <span class="d-none d-md-inline"><i class="far fa-bell"></i> Good news ! </span>
+            OctoBot version <span update-url="{{ url_for('api.upgrade_version') }}" id="upgradeVersion"></span>
+            is available.
+        </h5>
+        <a href="{{latest_release_url}}"  target="_blank" rel="noopener"
+           type="button" class="btn btn-sm btn-outline-primary waves-effect">
+            View latest release
+        </a>
     </div>
     {% endif %}
     <span id="exchange-specific-data">


### PR DESCRIPTION
(auto updater is disabled since release url are not available (can't dl from GH releases directly)) => use direct link instead of logging link in a log
![image](https://github.com/user-attachments/assets/8e4e5650-08ad-455d-afc3-5b461f229932)
